### PR TITLE
Fix scheduler and logging issues in BackgroundScheduleService

### DIFF
--- a/src/Atc.Hosting/BackgroundScheduleServiceBase.cs
+++ b/src/Atc.Hosting/BackgroundScheduleServiceBase.cs
@@ -218,7 +218,8 @@ public abstract class BackgroundScheduleServiceBase<T> : BackgroundService
                 }
                 else
                 {
-                    nextOccurrence = cronExpression.GetNextOccurrence(DateTime.UtcNow);
+                    logger.LogBackgroundServiceStopping(ServiceOptions.CronExpression, ServiceName);
+                    break;
                 }
             }
         }

--- a/src/Atc.Hosting/Extensions/LoggerExtensions.cs
+++ b/src/Atc.Hosting/Extensions/LoggerExtensions.cs
@@ -36,6 +36,16 @@ internal static partial class LoggerExtensions
         string serviceName);
 
     [LoggerMessage(
+        EventId = LoggingEventIdConstants.BackgroundService.Stopping,
+        Level = LogLevel.Warning,
+        Message = "No next occurrence found for cron expression '{CronExpression}'. Service {ServiceName} will stop",
+        SkipEnabledCheck = false)]
+    internal static partial void LogBackgroundServiceStopping(
+        this ILogger logger,
+        string cronExpression,
+        string serviceName);
+
+    [LoggerMessage(
         EventId = LoggingEventIdConstants.BackgroundService.Cancelled,
         Level = LogLevel.Warning,
         Message = "Cancellation invoked for worker {ServiceName}",

--- a/src/Atc.Hosting/Extensions/LoggerExtensions.cs
+++ b/src/Atc.Hosting/Extensions/LoggerExtensions.cs
@@ -57,7 +57,7 @@ internal static partial class LoggerExtensions
     [LoggerMessage(
         EventId = LoggingEventIdConstants.BackgroundService.Retrying,
         Level = LogLevel.Information,
-        Message = "Worker {ServiceName} will retry on next occurence pr the cron expression {CronExpression}",
+        Message = "Worker {ServiceName} will retry on next occurrence per the cron expression {CronExpression}",
         SkipEnabledCheck = false)]
     internal static partial void LogBackgroundServiceRetrying(
         this ILogger logger,

--- a/src/Atc.Hosting/LoggingEventIdConstants.cs
+++ b/src/Atc.Hosting/LoggingEventIdConstants.cs
@@ -9,5 +9,6 @@ public static class LoggingEventIdConstants
         public const int Stopped = 20002;
         public const int Cancelled = 20003;
         public const int UnhandledException = 20004;
+        public const int Stopping = 20005;
     }
 }


### PR DESCRIPTION
 Fix two issues in the background schedule service: correct a typo in a retry log message and properly handle the case where a cron expression has no next occurrence by stopping the service gracefully with a warning instead of silently recalculating.

### :bug: Fixes
- Stop service gracefully when cron expression has no next occurrence instead of silently retrying - avoid 100% CPU consumption until crash
- Correct "occurrence" spelling in retry log message